### PR TITLE
Add build and distribution support for components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 public/bundle.*
 package-lock.json
+dist

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
   "name": "svelte-app",
   "version": "1.0.0",
+  "main": "dist/bundle.umd.js",
+  "module": "dist/bundle.es.js",
+  "svelte.root": "src",
+  "files": [
+    "src",
+    "dist"
+  ],
   "devDependencies": {
+    "cross-env": "^5.0.5",
     "rollup": "^0.49.3",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^8.2.1",
@@ -11,7 +19,9 @@
     "serve": "^6.0.6"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build:umd": "cross-env FORMAT=umd rollup -c",
+    "build:es": "cross-env FORMAT=es rollup -c",
+    "build": "npm run build:umd && npm run build:es",
     "dev": "serve public & rollup -c -w",
     "start": "serve public"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,12 +6,32 @@ import uglify from 'rollup-plugin-uglify';
 
 const production = !process.env.ROLLUP_WATCH;
 
+const format = process.env.FORMAT || 'iife';
+const isUmd = format && format === 'umd';
+const isEs = format && format === 'es';
+
+const inputFile = (isUmd || isEs) ? 'src/components.js' : 'src/main.js';
+const outputCssFile = (isUmd || isEs) ? 'dist/bundle.css' : 'public/bundle.css';
+
+let outputFile;
+switch (format) {
+	case 'iife':
+		outputFile = 'public/bundle.js';
+		break;
+	case 'es':
+		outputFile = 'dist/bundle.es.js';
+		break;
+	case 'umd':
+		outputFile = 'dist/bundle.umd.js';
+		break;
+}
+
 export default {
-	input: 'src/main.js',	
+	input: inputFile,
 	output: {
-		sourcemap: true,	
-		format: 'iife',
-		file: 'public/bundle.js'
+		sourcemap: true,
+		format: format,
+		file: outputFile
 	},
 	name: 'app',
 	plugins: [
@@ -21,7 +41,7 @@ export default {
 			// we'll extract any component CSS out into
 			// a separate file — better for performance
 			css: css => {
-				css.write('public/bundle.css');
+				css.write(outputCssFile);
 			},
 
 			// this results in smaller CSS files
@@ -38,7 +58,7 @@ export default {
 
 		// If we're building for production (npm run build
 		// instead of npm run dev), transpile and minify
-		production && buble({ exclude: 'node_modules/**' }),
-		production && uglify()
+		production && isUmd && buble({ exclude: 'node_modules/**' }),
+		production && isUmd && uglify()
 	]
 };

--- a/src/components.js
+++ b/src/components.js
@@ -1,0 +1,3 @@
+import App from './App.html';
+
+export { App };

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import App from './App.html';
+import { App } from './components';
 
 const app = new App({
 	target: document.body,


### PR DESCRIPTION
Summary of changes - 
1. Add `umd` and `es` bundling for components in the application.
2. Configure `main`, `module` and `svelte.root` fields in `package.json` for easier consumption of components.

I can add distribution option for custom elements too if needed. Let me know.

Hope it's useful :).