### PR TITLE
add --single to allow clientside routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "rollup -c",
     "autobuild": "rollup -c -w",
     "dev": "run-p start:dev autobuild",
-    "start": "sirv public",
+    "start": "sirv public --single",
     "start:dev": "sirv public --dev --single"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "autobuild": "rollup -c -w",
     "dev": "run-p start:dev autobuild",
     "start": "sirv public",
-    "start:dev": "sirv public --dev"
+    "start:dev": "sirv public --dev --single"
   }
 }


### PR DESCRIPTION
hey!
stumpled upon this and couldnt find a reason to not have --single on by default.

>     -s, --single       Serve single-page applications
https://github.com/lukeed/sirv/tree/master/packages/sirv-cli