### PR TITLE
Add 'main' element to index.html so template matches Getting Started guide

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,16 @@
 </head>
 
 <body>
+	  <main>
+			<!-- main page content -->
+		</main>
+
+	<!-- 
+		Note: 
+		If you put this <script> tag referencing bundle.js above elements referenced by Svelte components as a target, 
+		you'll get an error about 'target' being a required function. This is because Svelte is trying to
+		find the element specified for a target (for ex, document.querySelector('main')) before the browser knows it exists.
+	-->
 	<script src='bundle.js'></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,15 @@
 import App from './App.html';
 
 const app = new App({
-	target: document.body,
+	target: document.querySelector('main'),
 	data: {
 		name: 'world'
 	}
 });
 
-export default app;
+// change the data associated with the template
+app.set({ name: 'everybody' });
+
+// detach the component and clean everything up
+// commented out for example's sake - or you wouldn't see anything!
+// app.destroy();


### PR DESCRIPTION
## Why this PR
As someone brand new to Svelte (and Rollup, and React-ish development for that matter), having the **Getting Started** tutorial not match the code in the repository it linked was very confusing - in particular `main.js` - because once I changed the file to match the guide, it broke.

My problem in particular was a missing `<main>` element - further exacerbated by me putting the bundle script above the `<main>` element. If I was used to working in Svelte it'd be a two-second "whoops, that was dumb" moment - but as a new user it took a lot longer to figure out.

`jg` on discord was very patient in explaining how things were working, but until he did so I was having one of those "everything I thought I knew was completely wrong" moments - which isn't the best initial experience.

## What I did
I added a `<main>` element to `index.html`, so that if/when the user copies code from the **Getting Started** guide into `main.js`, the template will continue to work without them having to edit `index.html` -- at that point, users might not realize that Svelte targets require `index.html` to have the element they reference, so supplying it with the template will make their initial learning process smoother.

## List of changes made
- Added `<main>` element to `index.html` so the `document.querySelector('main')` target used in the **Getting Started** guide doesn't cause an `Error: 'target' is a required option` error
- Added explanation with `<main>` element explaining that error (if they see it once they'll probably remember - doubt it needs to go in actual docs)
- Change `main.js` template to match the very first example for the guide
---
If y'all like this change, I will make one for the webpack repo as well - and/or the v3 branches
