### PR TITLE
Update rollup.config.js for deprecated Sveltev3 options

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,10 +15,6 @@ export default {
 	},
 	plugins: [
 		svelte({
-			// opt in to v3 behaviour today
-			skipIntroByDefault: true,
-			nestedTransitions: true,
-
 			// enable run-time checks when not in production
 			dev: !production,
 			// we'll extract any component CSS out into


### PR DESCRIPTION
This removes some now deprecated options in Svelte - having these in a rollup config will make the build fail with a `(svelte plugin) Error: Unrecognized option 'skipIntroByDefault'` error.

(AFAIK, this creates a problem when building a project using svelte v3.0.0-beta7, but were needed/recommended for previous v3 releases)