### PR TITLE
chore: update `sirv-cli` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "rollup-plugin-node-resolve": "^4.0.1",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^4.0.4",
-    "sirv-cli": "^0.2.3",
+    "sirv-cli": "^0.3.0",
     "svelte": "^2.16.1"
   },
   "scripts": {


### PR DESCRIPTION
The `sirv` packages are now [`0.3.0`](https://github.com/lukeed/sirv/releases/tag/v0.3.0).

As @Conduitry explained to me this morning, the new packages won't be picked up by semver automatically.