### PR TITLE
Add browser:true to rollup-plugin-node-resolve.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,7 @@ export default {
 		// some cases you'll need additional configuration —
 		// consult the documentation for details:
 		// https://github.com/rollup/rollup-plugin-commonjs
-		resolve(),
+		resolve({ browser: true }),
 		commonjs(),
 
 		// Watch the `public` directory and refresh the


### PR DESCRIPTION
Adds the `browser: true` setting to `rollup-plugin-node-resolve`. Resolves some problems people have when using external libraries that make use of the `browser` field in the `package.json`.