### PR TITLE
fix: correct charset declaration +

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,8 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
-	<meta charset='utf8'>
-	<meta name='viewport' content='width=device-width'>
+	<meta charset='utf-8'>
+	<meta name='viewport' content='width=device-width,initial-scale=1'>
 
 	<title>Svelte app</title>
 


### PR DESCRIPTION
Conform to https://www.w3.org/International/questions/qa-html-encoding-declarations by using `utf-8`, not `utf8`.
Add mobile-friendly initial scaling - copy value found at svelte.dev, developer.mozilla.org etc.