### PR TITLE
Move sirv-cli to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^4.0.4",
+    "sirv-cli": "^0.4.4",
     "svelte": "^3.0.0"
   },
   "dependencies": {
-    "sirv-cli": "^0.4.4"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
You _almost certainly_ didn't mean for sirv-cli to wind up in the dependencies list.