### PR TITLE
Remove compression step from Terser plugin

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,8 +41,10 @@ export default {
 		!production && livereload('public'),
 
 		// If we're building for production (npm run build
-		// instead of npm run dev), minify
-		production && terser()
+		// instead of npm run dev), obfuscate
+		production && terser({
+			compress: false
+		})
 	],
 	watch: {
 		clearScreen: false


### PR DESCRIPTION
Terser's compression of _bundle.js_ was causing breaking JS errors if any Svelte files
contained [`{#await ...}`](https://svelte.dev/docs#await) blocks. Compression is also unnecessary as _bundle.js_
has already been compressed in a previous build step.

Fixes #59 