### PR TITLE
Fix charset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-	<meta charset='utf8'>
+	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width'>
 
 	<title>Svelte app</title>


### PR DESCRIPTION
UTF-8 needs to have a dash, see e.g. the example
[here](https://www.w3.org/TR/html50/document-metadata.html#character-encoding-declaration).

The current value of `utf8` does not work with Internet Explorer 11. I guess most other browsers
will default to UTF-8 anyway when they encounter an unknown charset value.