### PR TITLE
fix for livereload not reloading from src directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "npm-run-all": "^4.1.5",
     "rollup": "^1.12.0",
     "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-livereload": "^1.0.0",
+    "rollup-plugin-livereload": "^1.0.4",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^4.0.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,7 +38,7 @@ export default {
 
 		// Watch the `public` directory and refresh the
 		// browser on changes when not in production
-		!production && livereload('public'),
+		!production && livereload(['src', 'public']),
 
 		// If we're building for production (npm run build
 		// instead of npm run dev), minify


### PR DESCRIPTION
live reload only works after the first change, then it stops working completely (seen this behaviour in both intelliJ and vim)
adding 'src' to the livereload config seems to fix that