### PR TITLE
don't start dev server until bundle is generated

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "svelte-app",
   "version": "1.0.0",
   "devDependencies": {
-    "npm-run-all": "^4.1.5",
     "rollup": "^1.12.0",
     "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-livereload": "^1.0.0",
@@ -16,8 +15,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "autobuild": "rollup -c -w",
-    "dev": "run-p start:dev autobuild",
+    "dev": "rollup -c -w",
     "start": "sirv public --single",
     "start:dev": "sirv public --single --dev"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,9 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
-import * as child_process from 'child_process';
+import rollup_start_dev from './rollup_start_dev';
 
 const production = !process.env.ROLLUP_WATCH;
-let running_dev_server = false;
 
 export default {
 	input: 'src/main.js',
@@ -40,18 +39,7 @@ export default {
 
 		// In dev mode, call `npm run start:dev` once
 		// the bundle has been generated
-		!production && {
-			writeBundle() {
-				if (!running_dev_server) {
-					running_dev_server = true;
-					child_process.spawn(
-						'npm',
-						['run', 'start:dev'],
-						{ stdio: ['ignore', 'inherit', 'inherit'] }
-					);
-				}
-			}
-		},
+		!production && rollup_start_dev,
 
 		// Watch the `public` directory and refresh the
 		// browser on changes when not in production

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,8 +3,10 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
+import * as child_process from 'child_process';
 
 const production = !process.env.ROLLUP_WATCH;
+let running_dev_server = false;
 
 export default {
 	input: 'src/main.js',
@@ -35,6 +37,21 @@ export default {
 			dedupe: importee => importee === 'svelte' || importee.startsWith('svelte/')
 		}),
 		commonjs(),
+
+		// In dev mode, call `npm run start:dev` once
+		// the bundle has been generated
+		!production && {
+			writeBundle() {
+				if (!running_dev_server) {
+					running_dev_server = true;
+					child_process.spawn(
+						'npm',
+						['run', 'start:dev'],
+						{ stdio: ['ignore', 'inherit', 'inherit'] }
+					);
+				}
+			}
+		},
 
 		// Watch the `public` directory and refresh the
 		// browser on changes when not in production

--- a/rollup_start_dev.js
+++ b/rollup_start_dev.js
@@ -1,0 +1,12 @@
+import * as child_process from 'child_process';
+
+let running_dev_server = false;
+
+export default {
+	writeBundle() {
+		if (!running_dev_server) {
+			running_dev_server = true;
+			child_process.spawn('npm', ['run', 'start:dev'], { stdio: ['ignore', 'inherit', 'inherit'] });
+		}
+	}
+};


### PR DESCRIPTION
Implements #72, along the lines I initially suggested.

Despite a couple of small unanticipated wrinkles, I still think this is better than introducing `rollup-plugin-serve` and its dependencies and introducing further divergence between prod and dev mode. It's nice to be able to configure how things are being served simply by editing the sirv comments in package.json.

The main ugly thing here for me is how we have to make sure we only start the server the _first_ time the bundle is written. If by chance someone has an idea how to tidy that up, I'd like to hear it.