### PR TITLE
Fix `warning: no license field`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "svelte-app",
   "version": "1.0.0",
+  "license": "MIT",
   "devDependencies": {
     "rollup": "^1.12.0",
     "rollup-plugin-commonjs": "^10.0.0",


### PR DESCRIPTION
Fixes `warning package.json: no license field` when running `yarn dev`