### PR TITLE
Move sirv-cli to dev deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ To create an optimised version of the app:
 npm run build
 ```
 
-You can run the newly built app with `npm run start`. This uses [sirv](https://github.com/lukeed/sirv), which is included in your package.json's `dependencies` so that the app will work when you deploy to platforms like [Heroku](https://heroku.com).
+You can run the newly built app with `npm run start`. This uses [sirv](https://github.com/lukeed/sirv), which is included in your package.json's `devDependencies`. When deploying to platforms like [Heroku](https://heroku.com), ensure `sirv-cli` is a production dependency.
+
+```js
+npm install --save-prod sirv-cli
+```
 
 
 ## Single-page app mode

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.2",
+    "sirv-cli": "^0.4.4",
     "svelte": "^3.0.0"
-  },
-  "dependencies": {
-    "sirv-cli": "^0.4.4"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
This has been discussed previously, most recently in #91 

It appears that `sirv-cli` is only needed in production deps in a handful (or just one, Heroku?) of scenarios. Because part of the beauty of svelte is the fact that there are no shipped dependencies, I would argue it's more important to support majority while documenting edge cases.

Thoughts? 🤗