### PR TITLE
Move scripts above deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "svelte-app",
   "version": "1.0.0",
+  "scripts": {
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
+    "start": "sirv public"
+  },
   "devDependencies": {
     "rollup": "^1.12.0",
     "rollup-plugin-commonjs": "^10.0.0",
@@ -12,10 +17,5 @@
   },
   "dependencies": {
     "sirv-cli": "^0.4.4"
-  },
-  "scripts": {
-    "build": "rollup -c",
-    "dev": "rollup -c -w",
-    "start": "sirv public"
   }
 }


### PR DESCRIPTION
QOL improvement. When installing new deps your package.json grows, pushing `scripts` down. Personally, I'm most likely scanning a package.json for available scripts and have always appreciated this being first.

Curious if there is an argument for having it at the bottom or if that's just how things ended up.

Cheers 🤗 