### PR TITLE
More explicit .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/node_modules/
+/public/build/
+
 .DS_Store
-node_modules
-public/build


### PR DESCRIPTION
This makes the `.gitignore` more explicit, in two ways:

- patterns are anchored to the root of the project
- directories are marked as such

The benefit is mainly exposing developers to these habits. They are easy to do, and they pay off as less surprises in bigger projects. This is where the value of having them in such a template matters. Letting more developers see `/node_modules/` instead of `node_modules` - though the end result would in this repo be the same.

I also suggest moving `.DS_Store` to the end of the file. My preference is to leave it out of project ignores - Mac people (like me) can have it in our global excludes. But if it is in the project include, I find the order of going from project specific (important) to more generic (IDEs, OS) to be nicer.