### PR TITLE
[update] - Replace rollup-plugin-commonjs with @rollup/plugin-commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "sirv public"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^10.0.0",
+    "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^6.0.0",
     "rollup": "^1.12.0",
     "rollup-plugin-livereload": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "sirv public"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^10.0.0",
     "@rollup/plugin-node-resolve": "^6.0.0",
     "rollup": "^1.12.0",
-    "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^6.0.0",
-    "rollup": "^1.12.0",
+    "rollup": "^1.20.0",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import svelte from 'rollup-plugin-svelte';
 import resolve from '@rollup/plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
+import commonjs from '@rollup/plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
 


### PR DESCRIPTION
As the ``rollup-plugin-commonjs`` plugin has been deprecated, an update is necessary 😄