### PR TITLE
Make `dev server respond with index.html to all unrecognized requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public"
+    "start": "sirv public --single index.html"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.0",


### PR DESCRIPTION
As of today, if anyone uses this template to create an app with some kind of routing library (e.g. `svelte-routing`) and they reload in any url but the root, the server won't respond.

I think this is not a good default for this template. Passing `--single index.html` will serve the index.html instead, which I think is nicer default.