### PR TITLE
add options in chokidar to use polling

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,7 +49,10 @@ export default {
 		production && terser()
 	],
 	watch: {
-		clearScreen: false
+		clearScreen: false,
+		chokidar: {
+			usePolling: true
+		}
 	}
 };
 


### PR DESCRIPTION
- fixes #109 
- chokidar is a transitive dependency of livereload, so passing an option to chokidar is relatively safe
- the fix was inspired by https://github.com/rollup/rollup/issues/1666#issuecomment-536227450
- tested on both macOS and Ubuntu 19 (via WSL2)