### PR TITLE
use improved dedupe in @rollup/plugin-node-resolve@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.0",
-    "@rollup/plugin-node-resolve": "^6.0.0",
+    "@rollup/plugin-node-resolve": "^7.0.0",
     "rollup": "^1.20.0",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default {
 		// https://github.com/rollup/plugins/tree/master/packages/commonjs
 		resolve({
 			browser: true,
-			dedupe: importee => importee === 'svelte' || importee.startsWith('svelte/')
+			dedupe: ['svelte']
 		}),
 		commonjs(),
 


### PR DESCRIPTION
https://github.com/rollup/plugins/pull/99 introduced a change to how `dedupe` works. It now matches just the package name, so we can use the array syntax, which is a bit less confusing.