### PR TITLE
Add support for aliases when importing components or source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.2",
+    "@rollup/plugin-alias": "^3.0.1",
     "svelte": "^3.0.0"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,8 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
+import path from "path";
+import alias from "@rollup/plugin-alias";
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -46,7 +48,18 @@ export default {
 
 		// If we're building for production (npm run build
 		// instead of npm run dev), minify
-		production && terser()
+		production && terser(),
+
+		// Add support for aliases when importing components or
+		// other source files using @ symbol which ponints to src
+		alias({
+			entries: [
+				{
+					find: "@",
+					replacement: path.resolve(__dirname, "src/")
+				}
+			]
+		})
 	],
 	watch: {
 		clearScreen: false


### PR DESCRIPTION
After developing small demos with svelte, I felt the need for a way to avoid using dots to navigate from a directory to another `import Button from "../../components/Button.svelte"` while importing a new file. A `vue/cli` generated project comes with an alias for the `src/` folder, which is the `@` symbol. So I decided to try the same approach in a Svelte project. 

PS: I also wrote a [blog post](https://changani.me/blog/2020/02/18/Import-svelte-components-using-an-alias/) talking about it. 

On this Pull Request I made the following changes:

- Installed `@rollup/plugins-alias` and added it to `devDependencies`
- Configured a new alias using `@` symbol to point to `src/` folder

I hope it's useful.