### PR TITLE
Proposing that --single to npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public"
+    "start": "sirv public --single"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.0",


### PR DESCRIPTION
I propose that the flag `--single` be added to the `npm run dev` script. This will allow fallback routing to work with the development server. 

This is important as new folks use this template to get started. When they add client side routing and they refresh on a client side route, the current behavior will result in a 404. By adding `--single` this will "just work"

This is documented in the readme here, but I believe that this should be the default.