### PR TITLE
public/index.html: make relative href

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,11 @@
 
 	<title>Svelte app</title>
 
-	<link rel='icon' type='image/png' href='/favicon.png'>
-	<link rel='stylesheet' href='/global.css'>
-	<link rel='stylesheet' href='/build/bundle.css'>
+	<link rel='icon' type='image/png' href='favicon.png'>
+	<link rel='stylesheet' href='global.css'>
+	<link rel='stylesheet' href='build/bundle.css'>
 
-	<script defer src='/build/bundle.js'></script>
+	<script defer src='build/bundle.js'></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Content

In index.html, relatively import the path under public.

## Background

I am using this template.
And I deploy using github pages.
Deployment destination URL is under the repository name, not the root.
I think there are other similar people.
At that time, I thought that a relative path was more convenient.