### PR TITLE
Bump rollup to v2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "start": "sirv public"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.0",
-    "@rollup/plugin-node-resolve": "^7.0.0",
-    "rollup": "^1.20.0",
-    "rollup-plugin-livereload": "^1.0.0",
-    "rollup-plugin-svelte": "^5.0.3",
-    "rollup-plugin-terser": "^5.1.2",
-    "svelte": "^3.0.0"
+    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-node-resolve": "^7.1.1",
+    "rollup": "^2.3.2",
+    "rollup-plugin-livereload": "^1.1.0",
+    "rollup-plugin-svelte": "^5.2.1",
+    "rollup-plugin-terser": "^5.3.0",
+    "svelte": "^3.20.1"
   },
   "dependencies": {
-    "sirv-cli": "^0.4.4"
+    "sirv-cli": "^0.4.5"
   }
 }


### PR DESCRIPTION
Bumps rollup to version 2.x. Also bumps the other packages to their latest minor/patch versions.

The `build`, `start`, and `dev` scripts all still work.

[**Rollup Changelog**](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#200)

_Question_: now that `rollup` has dropped support for Node < 10, should we add an [`"engines"`](https://docs.npmjs.com/files/package.json#engines) field to the `package.json` which specifies that you need at least Node 10+ to run it?

Closes #120 