### PR TITLE
chore: bump sirv-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
-    "sirv-cli": "^0.4.4"
+    "sirv-cli": "^1.0.0"
   }
 }


### PR DESCRIPTION
Maybe a WIP PR – I think with the changes in 1.0, it might be time to enable `--single` by default again since missing assets will 404 correctly now (#116)

Might also want to include a HTTPS or HTTP/2 step-by-step here (#128)?