### PR TITLE
Added host flag in npm run start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public"
+    "start": "sirv public --host"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^12.0.0",


### PR DESCRIPTION
Added --host flag in npm run start to start the server on the wifi network.

A very common question in our community is how to start a server on a Wi-Fi network. I suggest adding this flag to the template, as it is a useful feature that will not interfere with the development process.