### PR TITLE
fixes #144 - do not delete scripts folder if it is not empty

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -98,9 +98,11 @@ if (!argv[2]) {
   // Remove the script
   fs.unlinkSync(path.join(__filename))
 
-  // Check for Mac's DS_store file and remove it
-  const ds_storeFile = path.join(__dirname, 'DS_store')
-  if (fs.existsSync(ds_storeFile)) fs.unlinkSync(ds_storeFile)
+  // Check for Mac's DS_store file, and if it's the only one left remove it
+  const remainingFiles = fs.readdirSync(path.join(__dirname))
+  if (remainingFiles.length === 1 && remainingFiles[0] === 'DS_store') {
+    fs.unlinkSync(path.join(__dirname, 'DS_store'))
+  }
 
   // Check if the scripts folder is empty
   if (fs.readdirSync(path.join(__dirname)).length === 0) {

--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -97,12 +97,15 @@ fs.writeFileSync(tsconfigPath, tsconfig)
 if (!argv[2]) {
   // Remove the script
   fs.unlinkSync(path.join(__filename))
+
+  // Check for Mac's DS_store file and remove it
+  const ds_storeFile = path.join(__dirname, 'DS_store')
+  if (fs.existsSync(ds_storeFile)) fs.unlinkSync(ds_storeFile)
+
   // Check if the scripts folder is empty
   if (fs.readdirSync(path.join(__dirname)).length === 0) {
     // Remove the scripts folder
-    fs.rmdirSync(path.join(__dirname))     // just in case, keep the folder, there might be others scripts present
-  } else {
-    console.log('"scripts" folder not deleted. Folder not empty')
+    fs.rmdirSync(path.join(__dirname))
   }
 }
 

--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -101,7 +101,7 @@ if (!argv[2]) {
   // Check for Mac's DS_store file, and if it's the only one left remove it
   const remainingFiles = fs.readdirSync(path.join(__dirname))
   if (remainingFiles.length === 1 && remainingFiles[0] === '.DS_store') {
-    fs.unlinkSync(path.join(__dirname, 'DS_store'))
+    fs.unlinkSync(path.join(__dirname, '.DS_store'))
   }
 
   // Check if the scripts folder is empty

--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -97,8 +97,13 @@ fs.writeFileSync(tsconfigPath, tsconfig)
 if (!argv[2]) {
   // Remove the script
   fs.unlinkSync(path.join(__filename))
-  // Remove the scripts folder
-  fs.rmdirSync(path.join(__dirname))
+  // Check if the scripts folder is empty
+  if (fs.readdirSync(path.join(__dirname)).length === 0) {
+    // Remove the scripts folder
+    fs.rmdirSync(path.join(__dirname))     // just in case, keep the folder, there might be others scripts present
+  } else {
+    console.log('"scripts" folder not deleted. Folder not empty')
+  }
 }
 
 // Adds the extension recommendation

--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -100,7 +100,7 @@ if (!argv[2]) {
 
   // Check for Mac's DS_store file, and if it's the only one left remove it
   const remainingFiles = fs.readdirSync(path.join(__dirname))
-  if (remainingFiles.length === 1 && remainingFiles[0] === 'DS_store') {
+  if (remainingFiles.length === 1 && remainingFiles[0] === '.DS_store') {
     fs.unlinkSync(path.join(__dirname, 'DS_store'))
   }
 


### PR DESCRIPTION
I'm not sure if the message is really that useful, perhaps it would be better to silently skip the removal of the folder, if it's not empty