### PR TITLE
Bump svelte-check version

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -22,7 +22,7 @@ const projectRoot = argv[2] || path.join(__dirname, "..")
 // Add deps to pkg.json
 const packageJSON = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"))
 packageJSON.devDependencies = Object.assign(packageJSON.devDependencies, {
-  "svelte-check": "^0.1.0",
+  "svelte-check": "^1.0.0",
   "svelte-preprocess": "^4.0.0",
   "@rollup/plugin-typescript": "^4.0.0",
   "typescript": "^3.9.3",


### PR DESCRIPTION
It's now at `1.0.0`. Needs to be updated because the interaction with `svelte-language-server` changed, old versions with new `svelte-language-server` versions will be broke.