### PR TITLE
fix-padding-input-range-chrome

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -32,6 +32,7 @@ label {
 input, button, select, textarea {
 	font-family: inherit;
 	font-size: inherit;
+	-webkit-padding: 0.4em 0;
 	padding: 0.4em;
 	margin: 0 0 0.5em 0;
 	box-sizing: border-box;


### PR DESCRIPTION
Fixes https://github.com/sveltejs/svelte/issues/5234

<img width="302" alt="Image 2020-08-03 at 8 46 09 PM" src="https://user-images.githubusercontent.com/2502947/89245224-5c829200-d5d6-11ea-87ed-000b18a482d7.png">
to this
<img width="875" alt="Image 2020-08-03 at 10 12 52 PM" src="https://user-images.githubusercontent.com/2502947/89245302-863bb900-d5d6-11ea-9dff-1196313d3b3a.png">
