### PR TITLE
Explain how to run the app on a different port

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Navigate to [localhost:5000](http://localhost:5000). You should see your app run
 
 By default, the server will only respond to requests from localhost. To allow connections from other computers, edit the `sirv` commands in package.json to include the option `--host 0.0.0.0`.
 
+If you don't see the "HELLO WORLD!" page on [localhost:5000](http://localhost:5000) it might be due to another process using that port. To use a different port, e.g. `5050`, modify the line `"start": "sirv public"` in the `package.json` file to `"start": "sirv public --port 5050"`.
 
 ## Building and running in production mode
 


### PR DESCRIPTION
I followed the tutorial step-by-step but the hello-world app was not showing on localhost:5000. As other people found out there was a process running on the port 5000, a docker process in my case. I didn't want to kill that process so I figured out a way to use a different port.

It would be nice to either have it use a random port or make it fail if the port is already in use but I don't know how to do that as I'm new to node & JS.