### PR TITLE
Upgrade rollup-plugin-terser to 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "rollup": "^2.3.4",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",
-    "rollup-plugin-terser": "^6.0.0",
+    "rollup-plugin-terser": "^7.0.0",
     "svelte": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Adds terser support for optional chaining