### PR TITLE
Setting dynamic quote to replace entry point

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -60,7 +60,7 @@ import sveltePreprocess from 'svelte-preprocess';
 import typescript from '@rollup/plugin-typescript';`)
 
 // Replace name of entry point
-rollupConfig = rollupConfig.replace(`'src/main.js'`, `'src/main.ts'`)
+rollupConfig = rollupConfig.replace(/("|'|`)src\/main\.js("|'|`)/, '$1src/main.ts$1')
 
 // Add preprocess to the svelte config, this is tricky because there's no easy signifier.
 // Instead we look for `css:` then the next `}` and add the preprocessor to that


### PR DESCRIPTION
Some people have different `quote` configurations in their Code Editor. To overcome this possibility, I changed the quote setting at the entry point regex to be more dynamic.