### PR TITLE
TS: Add sourcemaps, prevent dev shutdown on error

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -82,7 +82,7 @@ while (( match = configEditor.exec(rollupConfig)) != null) {
 // Add TypeScript
 rollupConfig = rollupConfig.replace(
   'commonjs(),',
-  'commonjs(),\n\t\ttypescript({\n\t\t\tsourceMap: !production,\n\t\t\tinlineSources: !production,\n\t\t\tnoEmitOnError: production\n\t\t}),'
+  'commonjs(),\n\t\ttypescript({\n\t\t\tsourceMap: !production,\n\t\t\tinlineSources: !production\n\t\t}),'
 );
 fs.writeFileSync(rollupConfigPath, rollupConfig)
 

--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -80,7 +80,10 @@ while (( match = configEditor.exec(rollupConfig)) != null) {
 
 
 // Add TypeScript
-rollupConfig = rollupConfig.replace("commonjs(),", 'commonjs(),\n\t\ttypescript({ sourceMap: !production }),')
+rollupConfig = rollupConfig.replace(
+  'commonjs(),',
+  'commonjs(),\n\t\ttypescript({\n\t\t\tsourceMap: !production,\n\t\t\tinlineSources: !production,\n\t\t\tnoEmitOnError: production\n\t\t}),'
+);
 fs.writeFileSync(rollupConfigPath, rollupConfig)
 
 // Add TSConfig


### PR DESCRIPTION
Add sourcemaps, fixes #145 
The original code is not inlined into the source map files by default. I guess this happens to save file sizes and because you could just as well get the code from the original file which is referenced as a relative path. For dev mode this does not work however because sirv only serves the files inside public, so inline them in that case.

Prevent shutdown on error
~~When there is a TS syntax error, the server will be shut down because the rollup plugin throws an error, because they set noEmitOnError to true by default. Change it so that this is only the case when building, not during dev.~~ EDIT: This is no longer needed because v6 of the TS plugin will no longer set `noEmitOnError`.