### PR TITLE
Remove trailing `,` in tsconfig.json

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -91,7 +91,7 @@ const tsconfig = `{
   "extends": "@tsconfig/svelte/tsconfig.json",
 
   "include": ["src/**/*"],
-  "exclude": ["node_modules/*", "__sapper__/*", "public/*"],
+  "exclude": ["node_modules/*", "__sapper__/*", "public/*"]
 }`
 const tsconfigPath =  path.join(projectRoot, "tsconfig.json")
 fs.writeFileSync(tsconfigPath, tsconfig)


### PR DESCRIPTION
With this `,` the JSON is technically invalid and doesn't work when you replace `@rollup/plugin-typescript` with `rollup-plugin-esbuild`.

`rollup.config.js`:
```js
// ...
// import typescript from '@rollup/plugin-typescript';
import esbuild from 'rollup-plugin-esbuild';
// ...
		// typescript({
		// 	sourceMap: !production,
		// 	inlineSources: !production
		// }),
		esbuild({
			minify: production
		}),
// ...
		// production && terser()
```

Error:
```
src/main.ts → public/build/bundle.js...
[!] (plugin esbuild) SyntaxError: Unexpected token } in JSON at position 138
src/main.ts
SyntaxError: Unexpected token } in JSON at position 138
    at JSON.parse (<anonymous>)
    at Object.load (/home/nymous/Documents/GitHub/nymous/svelte-ts-tutorial/node_modules/rollup-plugin-esbuild/dist/index.js:21:17)
```