### PR TITLE
svelte app on div instead of body

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,5 +14,6 @@
 </head>
 
 <body>
+	<div id="root"></div>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import App from './App.svelte';
 
 const app = new App({
-	target: document.body,
+	target: document.getElementById('root'),
 	props: {
 		name: 'world'
 	}


### PR DESCRIPTION
Svelte app is drawn on body, that is app is binding to body.
Sometimes it make difficult to embed svelte app into other html.

This commit:
Svelte app is drawn on div with id "root" for flexibility.
