### PR TITLE
do not fail when there is the .vscode folder already

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -104,7 +104,7 @@ if (!argv[2]) {
 }
 
 // Adds the extension recommendation
-fs.mkdirSync(path.join(projectRoot, ".vscode"))
+fs.mkdirSync(path.join(projectRoot, ".vscode"), { recursive: true })
 fs.writeFileSync(path.join(projectRoot, ".vscode", "extensions.json"), `{
   "recommendations": ["svelte.svelte-vscode"]
 }


### PR DESCRIPTION
Hi,
I wanted to run the setupTypeScript.js script after I made some changes to my project. I had the .vscode folder already created and the script failed as it tried to create the folder again.

I know that users should "run it immediately after cloning the template", but I still think this is a good improvement.