### PR TITLE
Add github action for typescript template

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,33 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: node scripts/setupTypeScript.js
+    - uses: actions/upload-artifact@v2
+      with:
+        name: my-artifact
+        path: ./
+

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-and-move:
 
     runs-on: ubuntu-latest
 
@@ -26,8 +26,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: node scripts/setupTypeScript.js
-    - uses: actions/upload-artifact@v2
+    - name: Copy
+      uses: andstor/copycat-action@v3
       with:
-        name: my-artifact
-        path: ./
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: /.
+        dst_path: /.
+        dst_owner: sveltejs
+        dst_repo_name: template-typescript
 


### PR DESCRIPTION
**Open Todos:**

- [ ] create sveltejs/template-typescript with master branch
- [ ] add secret PERSONAL_TOKEN with workflow access (see [here](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow))

Optionally the svelte site docs can be updated so the template for typescript can be used directly.

**For reference:**
Files where succesfully copied to [this repo](https://github.com/dreitzner/template-typescript)

closes #206 