### PR TITLE
Stop sirv before reloading rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
 import css from 'rollup-plugin-css-only';
+import { spawn } from 'child_process';
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -11,20 +12,31 @@ function serve() {
 	let server;
 
 	function toExit() {
-		if (server) server.kill(0);
+		if (server) {
+			/* On linux, server.kill() only kills the parent shell (sh) process but not the child sirv instance
+			   See https://nodejs.org/docs/latest-v14.x/api/child_process.html#child_process_subprocess_kill_signal
+			   Passing the negation of PID of a detached process to 'kill' stops all its children */ 
+			try {
+				spawn('kill', ['--', `-${server.pid}`]);
+			} catch (_) {
+				server.kill();
+			}
+		}
 	}
 
 	return {
 		writeBundle() {
 			if (server) return;
-			server = require('child_process').spawn('npm', ['run', 'start', '--', '--dev'], {
+			server = spawn('npm', ['start', '--', '--dev'], {
 				stdio: ['ignore', 'inherit', 'inherit'],
-				shell: true
+				detached: true,
 			});
-
 			process.on('SIGTERM', toExit);
 			process.on('exit', toExit);
-		}
+		},
+		/* Rollup restarts on detecting changes to this config file.
+		   This hook makes sure the previously started sirv instance is stopped before starting a new one */
+		closeWatcher: toExit,
 	};
 }
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/template/issues/199

Rollup reloads the config on detecting changes in it. This should also restart the `sirv` server. But the current config keeps creating new instances of `sirv` on each reload without properly stopping the previous ones. This PR fixes that behaviour.