### PR TITLE
Open svelte tutorial in a new window

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,7 +4,7 @@
 
 <main>
 	<h1>Hello {name}!</h1>
-	<p>Visit the <a href="https://svelte.dev/tutorial">Svelte tutorial</a> to learn how to build Svelte apps.</p>
+	<p>Visit the <a href="https://svelte.dev/tutorial/basics" target="_blank">Svelte tutorial</a> to learn how to build Svelte apps.</p>
 </main>
 
 <style>


### PR DESCRIPTION
As a learning Svelte position, I found it more useful to keep my window using `a:target=_blank` when accessing the tutorial.

And the tutorial's url seems to have changed a bit, so modified it.