### PR TITLE
Set private to true in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "svelte-app",
   "version": "1.0.0",
+  "private": true,
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",


### PR DESCRIPTION
This settings prevents users from accidentally publishing their svelte code to an NPM registry.
Almost no user will want to publish their app to NPM, and if they wish to do so they can safely set `private: false`.

`private: true` does not imply that the project is private, it just prevents accidents around `npm publish` from happening.