### PR TITLE
use `sirv --no-clear` to keep terminal history

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public"
+    "start": "sirv public --no-clear"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",


### PR DESCRIPTION
currently, the last ~20 lines are removed by sirv, so warnings from rollup are lost
even if that bug in sirv was fixed, i dont want to scroll back my terminal just to see bundler warnings

edit: commits got mixed up, lemme fix ...
edit: done