### PR TITLE
add --single option

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c --single",
     "dev": "rollup -c -w",
-    "start": "sirv public --no-clear"
+    "start": "sirv public --no-clear --single"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",


### PR DESCRIPTION
currently html5 routes like http://localhost:5000/somepage/pageid interpreted as 404 by rollup in dev mode.
To fix that we usually rewrite all unexisting routes to index.html
We can configure rollup to behave like expected passing additional param "--single"