### PR TITLE
fix ts sourceMap warning on prod build

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -5,7 +5,7 @@
   <script lang="ts">
   	export let name: string;
   </script>
- 
+
   As well as validating the code for CI.
   */
 
@@ -71,7 +71,7 @@ rollupConfig = rollupConfig.replace(
 // Add TypeScript
 rollupConfig = rollupConfig.replace(
   'commonjs(),',
-  'commonjs(),\n\t\ttypescript({\n\t\t\tsourceMap: !production,\n\t\t\tinlineSources: !production\n\t\t}),'
+  'commonjs(),\n\t\ttypescript({\n\t\t\tsourceMap: production,\n\t\t\tinlineSources: !production\n\t\t}),'
 );
 fs.writeFileSync(rollupConfigPath, rollupConfig)
 


### PR DESCRIPTION
This PR will change the following config

```
typescript({ sourceMap: !production})
typescript({ sourceMap: production })   
```

It will remove the negation on sourceMap and removes the following warning:
`(!) Plugin typescript: @rollup/plugin-typescript: Typescript 'sourceMap' compiler option must be set to generate source maps.`

Fixes #174 