### PR TITLE
fix(style): Fix small styling inconsistencies

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -1,15 +1,15 @@
 html, body {
+	height: 100%;
 	position: relative;
 	width: 100%;
-	height: 100%;
 }
 
 body {
+	box-sizing: border-box;
 	color: #333;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	margin: 0;
 	padding: 8px;
-	box-sizing: border-box;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
 a {
@@ -30,14 +30,14 @@ label {
 }
 
 input, button, select, textarea {
+	-webkit-padding: 0.4em 0;
+	border-radius: 2px;
+	border: 1px solid #ccc;
+	box-sizing: border-box;
 	font-family: inherit;
 	font-size: inherit;
-	-webkit-padding: 0.4em 0;
-	padding: 0.4em;
 	margin: 0 0 0.5em 0;
-	box-sizing: border-box;
-	border: 1px solid #ccc;
-	border-radius: 2px;
+	padding: 0.4em;
 }
 
 input:disabled {
@@ -45,8 +45,8 @@ input:disabled {
 }
 
 button {
-	color: #333;
 	background-color: #f4f4f4;
+	color: #333;
 	outline: none;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
 <head>
 	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width,initial-scale=1'>

--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -2,10 +2,10 @@
 
 /** This script modifies the project to support TS code in .svelte files like:
 
-  <script lang="ts">
+  <script lang='ts'>
   	export let name: string;
   </script>
- 
+
   As well as validating the code for CI.
   */
 
@@ -13,14 +13,14 @@
   rm -rf test-template template && git clone sveltejs/template test-template && node scripts/setupTypeScript.js test-template
 */
 
-const fs = require("fs")
-const path = require("path")
-const { argv } = require("process")
+const fs = require('fs')
+const path = require('path')
+const { argv } = require('process')
 
-const projectRoot = argv[2] || path.join(__dirname, "..")
+const projectRoot = argv[2] || path.join(__dirname, '..')
 
 // Add deps to pkg.json
-const packageJSON = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"))
+const packageJSON = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'))
 packageJSON.devDependencies = Object.assign(packageJSON.devDependencies, {
   "svelte-check": "^1.0.0",
   "svelte-preprocess": "^4.0.0",
@@ -36,23 +36,23 @@ packageJSON.scripts = Object.assign(packageJSON.scripts, {
 })
 
 // Write the package JSON
-fs.writeFileSync(path.join(projectRoot, "package.json"), JSON.stringify(packageJSON, null, "  "))
+fs.writeFileSync(path.join(projectRoot, 'package.json'), JSON.stringify(packageJSON, null, '  '))
 
 // mv src/main.js to main.ts - note, we need to edit rollup.config.js for this too
-const beforeMainJSPath = path.join(projectRoot, "src", "main.js")
-const afterMainTSPath = path.join(projectRoot, "src", "main.ts")
+const beforeMainJSPath = path.join(projectRoot, 'src', 'main.js')
+const afterMainTSPath = path.join(projectRoot, 'src', 'main.ts')
 fs.renameSync(beforeMainJSPath, afterMainTSPath)
 
 // Switch the app.svelte file to use TS
-const appSveltePath = path.join(projectRoot, "src", "App.svelte")
-let appFile = fs.readFileSync(appSveltePath, "utf8")
-appFile = appFile.replace("<script>", '<script lang="ts">')
-appFile = appFile.replace("export let name;", 'export let name: string;')
+const appSveltePath = path.join(projectRoot, 'src', 'App.svelte')
+let appFile = fs.readFileSync(appSveltePath, 'utf8')
+appFile = appFile.replace('<script>', '<script lang=\'ts\'>')
+appFile = appFile.replace('export let name;', 'export let name: string;')
 fs.writeFileSync(appSveltePath, appFile)
 
 // Edit rollup config
-const rollupConfigPath = path.join(projectRoot, "rollup.config.js")
-let rollupConfig = fs.readFileSync(rollupConfigPath, "utf8")
+const rollupConfigPath = path.join(projectRoot, 'rollup.config.js')
+let rollupConfig = fs.readFileSync(rollupConfigPath, 'utf8')
 
 // Edit imports
 rollupConfig = rollupConfig.replace(`'rollup-plugin-terser';`, `'rollup-plugin-terser';
@@ -82,7 +82,7 @@ const tsconfig = `{
   "include": ["src/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "public/*"]
 }`
-const tsconfigPath =  path.join(projectRoot, "tsconfig.json")
+const tsconfigPath =  path.join(projectRoot, 'tsconfig.json')
 fs.writeFileSync(tsconfigPath, tsconfig)
 
 // Delete this script, but not during testing
@@ -104,14 +104,14 @@ if (!argv[2]) {
 }
 
 // Adds the extension recommendation
-fs.mkdirSync(path.join(projectRoot, ".vscode"), { recursive: true })
-fs.writeFileSync(path.join(projectRoot, ".vscode", "extensions.json"), `{
+fs.mkdirSync(path.join(projectRoot, '.vscode'), { recursive: true })
+fs.writeFileSync(path.join(projectRoot, '.vscode', 'extensions.json'), `{
   "recommendations": ["svelte.svelte-vscode"]
 }
 `)
 
-console.log("Converted to TypeScript.")
+console.log('Converted to TypeScript.')
 
-if (fs.existsSync(path.join(projectRoot, "node_modules"))) {
-  console.log("\nYou will need to re-run your dependency manager to get started.")
+if (fs.existsSync(path.join(projectRoot, 'node_modules'))) {
+  console.log('\nYou will need to re-run your dependency manager to get started.')
 }


### PR DESCRIPTION
This PR fixes small code style inconsistency and is specifically targeted to avoid trigerring linting freaks like myself. 

Main changes: 
- Ordered CSS rules;
- Added single quotes where they were not used (according to [this](https://github.com/sveltejs/eslint-config/blob/master/index.js#L28));

Important question here would be `Why not to integrate @sveltejs/eslint-config here?`. And the answer is very simple - it'd require to install `typescript` and [5 more dependencies](https://github.com/sveltejs/eslint-config/blob/master/package.json#L29) that would not be used by non-typescript/non-eslint projects. 

I can't imagine a smaller contribution to svelte, but you have to start with something, right? 😄 