### PR TITLE
Update svelte-check and tsconfig-base in setupTypeScript

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -22,7 +22,7 @@ const projectRoot = argv[2] || path.join(__dirname, "..")
 // Add deps to pkg.json
 const packageJSON = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"))
 packageJSON.devDependencies = Object.assign(packageJSON.devDependencies, {
-  "svelte-check": "^1.6.0",
+  "svelte-check": "^2.0.0",
   "svelte-preprocess": "^4.0.0",
   "@rollup/plugin-typescript": "^8.0.0",
   "typescript": "^4.0.0",

--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -22,17 +22,17 @@ const projectRoot = argv[2] || path.join(__dirname, "..")
 // Add deps to pkg.json
 const packageJSON = JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"))
 packageJSON.devDependencies = Object.assign(packageJSON.devDependencies, {
-  "svelte-check": "^1.0.0",
+  "svelte-check": "^1.6.0",
   "svelte-preprocess": "^4.0.0",
   "@rollup/plugin-typescript": "^8.0.0",
   "typescript": "^4.0.0",
   "tslib": "^2.0.0",
-  "@tsconfig/svelte": "^1.0.0"
+  "@tsconfig/svelte": "^2.0.0"
 })
 
 // Add script for checking
 packageJSON.scripts = Object.assign(packageJSON.scripts, {
-  "validate": "svelte-check"
+  "check": "svelte-check --tsconfig ./tsconfig.json"
 })
 
 // Write the package JSON
@@ -84,6 +84,10 @@ const tsconfig = `{
 }`
 const tsconfigPath =  path.join(projectRoot, "tsconfig.json")
 fs.writeFileSync(tsconfigPath, tsconfig)
+
+// Add global.d.ts
+const dtsPath =  path.join(projectRoot, "src", "global.d.ts")
+fs.writeFileSync(dtsPath, `/// <reference types="svelte" />`)
 
 // Delete this script, but not during testing
 if (!argv[2]) {


### PR DESCRIPTION
- since `svelte-check` 1.6.0, one can pass a tsconfig path and get better diagnostics (scoped to the project files, including TS/JS) -> update accordingly
- `@tsconfig/svelte` 2.0.0 doesn't includes `"types": ["svelte"]` anymore, which will avoid confusion around other global types not getting picked up. To not get errors in TS files when importing Svelte files, a new `global.d.ts` is added which contains a reference so those types which were previously provided through the `"types"` option are picked up

Draft, merge as soon as `@tsconfig/svelte` is really released.