### PR TITLE
fix: warning when npm run build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,7 @@ function serve() {
 export default {
 	input: 'src/main.js',
 	output: {
-		sourcemap: true,
+		sourcemap: !production,
 		format: 'iife',
 		name: 'app',
 		file: 'public/build/bundle.js'


### PR DESCRIPTION
fix: warning when npm run build
`(!) Plugin typescript: @rollup/plugin-typescript: Rollup 'sourcemap' option must be set to generate source maps.`