### PR TITLE
fix build command breaking with typescript set up

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -25,7 +25,7 @@ packageJSON.devDependencies = Object.assign(packageJSON.devDependencies, {
   "svelte-check": "^2.0.0",
   "svelte-preprocess": "^4.0.0",
   "@rollup/plugin-typescript": "^8.0.0",
-  "typescript": "^4.0.0",
+  "typescript": "4.3.5",
   "tslib": "^2.0.0",
   "@tsconfig/svelte": "^2.0.0"
 })


### PR DESCRIPTION
This is intended as a hotfix for #255 so that the recommended method of using typescript with svelte isn't broken while we look for the root cause for typescript ^4.4 breaking svelte's build command