### PR TITLE
Updates vercel deployment instructions to use project-linking instead of --name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ Install `vercel` if you haven't already:
 npm install -g vercel
 ```
 
-Then, from within your project folder:
+Then, from within your project folder run:
 
 ```bash
-cd public
-vercel deploy --name my-project
+vercel
 ```
+
+and follow the [project linking](https://vercel.com/docs/cli#commands/overview/project-linking) process.
 
 ### With [surge](https://surge.sh/)
 


### PR DESCRIPTION
I run into a [deprecation warning](https://vercel.com/docs/cli#commands/overview/unique-options/name) from the vercel cli when deploying my project and I thought it'd be helpful to update the docs:
