### PR TITLE
chore: bump `sirv-cli` version;

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install
 npm run dev
 ```
 
-Navigate to [localhost:5000](http://localhost:5000). You should see your app running. Edit a component file in `src`, save it, and reload the page to see your changes.
+Navigate to [localhost:8080](http://localhost:8080). You should see your app running. Edit a component file in `src`, save it, and reload the page to see your changes.
 
 By default, the server will only respond to requests from localhost. To allow connections from other computers, edit the `sirv` commands in package.json to include the option `--host 0.0.0.0`.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
-    "sirv-cli": "^1.0.0"
+    "sirv-cli": "^2.0.0"
   }
 }


### PR DESCRIPTION
The `sirv-cli@2.x` cycle changed its default from `5000` to `8080` because of macOS Monterey conflicts

- Closes #181
- Closes #184
- Closes #277