### PR TITLE
fix: macOS "port 5000 is already in use" issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public --no-clear"
+    "start": "sirv public --no-clear --port 3000"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",


### PR DESCRIPTION
On macOS Monterey port 5000 is used by an AirPlay Receiver. Changing port to, for example, 3000 resolves the issue.

If PR is accepted, the change should be reflected in README.