### PR TITLE
Fix the error when importing TypeScript files in Svelte files

### DIFF
--- a/scripts/setupTypeScript.js
+++ b/scripts/setupTypeScript.js
@@ -71,7 +71,7 @@ rollupConfig = rollupConfig.replace(
 // Add TypeScript
 rollupConfig = rollupConfig.replace(
   'commonjs(),',
-  'commonjs(),\n\t\ttypescript({\n\t\t\tsourceMap: !production,\n\t\t\tinlineSources: !production\n\t\t}),'
+  'commonjs(),\n\t\ttypescript({\n\t\t\tsourceMap: !production,\n\t\t\tinlineSources: !production,\n\t\t\trootDir: "./src"\n\t\t}),'
 );
 fs.writeFileSync(rollupConfigPath, rollupConfig)
 


### PR DESCRIPTION
As was reported in https://github.com/sveltejs/template/issues/244, when using the current template, importing a TypeScript file in Svelte files, e.g. 

```ts
import { foo } from './utility';
```

causes this error:

```
[!] Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
```

Although the fix in this PR works, another workaround is posted on the issue, which might fit better.

Fix https://github.com/sveltejs/template/issues/244.
