### PR TITLE
Fixed the absolute paths index.html to relative paths

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,11 @@
 
 	<title>Svelte app</title>
 
-	<link rel='icon' type='image/png' href='/favicon.png'>
-	<link rel='stylesheet' href='/global.css'>
-	<link rel='stylesheet' href='/build/bundle.css'>
+	<link rel='icon' type='image/png' href='./favicon.png'>
+	<link rel='stylesheet' href='./global.css'>
+	<link rel='stylesheet' href='./build/bundle.css'>
 
-	<script defer src='/build/bundle.js'></script>
+	<script defer src='./build/bundle.js'></script>
 </head>
 
 <body>


### PR DESCRIPTION
Fixes the file paths. For some reason the template has absolute paths and this breaks different ways of serving the file with seemingly no benefits. Making the file paths relative fixes this. 